### PR TITLE
Add Swagger and ReDoc documentation endpoints for the API

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
     'accounts.apps.AccountsConfig',
 ]
 

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -14,11 +14,31 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 from . import views
 
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Betting API",
+        default_version="v1",
+        description="API documentation for the Betting application",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contact@betting.local"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('health/', views.health),
+    path("admin/", admin.site.urls),
+    path("health/", views.health),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]


### PR DESCRIPTION
This pull request introduces changes to add API documentation to the Betting application using `drf_yasg`. The main changes include updating the settings to include `drf_yasg` and modifying the URL configurations to serve the Swagger and Redoc documentation.

API Documentation:

* [`server/server/settings.py`](diffhunk://#diff-0611d7687a9381e53d81c341f0fabbaeb42a9774d0c72d53b509df5b6a5f4e9aR44): Added `drf_yasg` to the list of installed applications.
* [`server/server/urls.py`](diffhunk://#diff-7523d5cb7d1c14be0074d7952077799ae2f8bdabb0754f9436b5cbb274940855R17-R43): Imported necessary modules from `drf_yasg` and `rest_framework`. Created a `schema_view` for API documentation and added URL patterns for Swagger and Redoc documentation.